### PR TITLE
VULCAN-004: Configure .gitignore and basic repo settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+#
+# https://help.github.com/articles/dealing-with-line-endings/
+#
+# Linux start script should use lf
+/gradlew        text eol=lf
+
+# These are Windows script files and should use crlf
+*.bat           text eol=crlf
+
+# Normalize line endings for cross-platform compatibility
+* text=auto eol=lf
+
+# Treat these as text files
+*.java text
+*.feature text
+*.md text
+*.properties text
+*.xml text
+*.yml text
+*.yaml text
+*.json text
+
+# Mark binary files to avoid diff noise
+*.jar binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.zip binary
+
+# Ensure feature files are UTF-8 encoded
+*.feature linguist-language=Cucumber
+
+# Keep shell scripts executable
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,64 @@
+############################
+# Gradle
+############################
+.gradle/
+build/
+out/
+
+# Gradle Wrapper JAR (optional to ignore)
+# gradle/wrapper/gradle-wrapper.jar
+
+# Local Gradle config
+gradle-app.setting
+
+############################
+# Java
+############################
+*.class
+*.log
+
+############################
+# IntelliJ / JetBrains
+############################
+.idea/
+*.iml
+*.iws
+*.ipr
+
+# IntelliJ project-specific files
+out/
+# SonarLint
+.sonarlint/
+
+############################
+# VS Code (if ever used)
+############################
+.vscode/
+
+############################
+# macOS system files
+############################
+.DS_Store
+.AppleDouble
+.LSOverride
+
+############################
+# Cucumber Reports
+############################
+cucumber-report/
+reports/
+test-output/
+target/
+
+############################
+# Logs
+############################
+*.log
+logs/
+
+############################
+# Temporary Files
+############################
+*.tmp
+*.temp
+~$*


### PR DESCRIPTION
.gitignore:
	•	Prevent committing build files
	•	Ignore IntelliJ noise
	•	Ignore macOS system files
	•	Ignore logs and reports
	•	Keep your repo clean and lightweight

.gitattributes
 1. Line endings (CRLF vs LF)
          Very important when working on:
	       • macOS (LF)
	       • Windows (CRLF)
	       • Linux (LF)
        • It prevents problems like:
	    • “File changed but nothing changed”
	    • Weird diffs
	    • Broken shell scripts
	    • Cucumber features not running because of wrong line endings
        • GitHub even recommends defining this.
2.  File type normalization
    Git can be told:
	•	Treat this file as binary
	•	Treat this file as text
	•	Don’t diff this file
	•	Use special merge rules

Examples:
	•	Prevent .jar or .png from showing diff noise
	•	Ensure .feature files stay UTF-8 encoded
3.  Custom diff behavior
Useful for code like:
	•	.md (Markdown diffs)
	•	.json
	•	.yml
4.  Locking files in LFS (Git Large File Storage)
For large binary files.