### PR TITLE
VULCAN-0011: Introduce Log4j2 as the logging framework for VulcanTest…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ dependencies {
 
     // WebDriverManager (automatic driver downloads)
     testImplementation 'io.github.bonigarcia:webdrivermanager:5.7.0'
+
+    // Logging - Log4j2
+    testImplementation 'org.apache.logging.log4j:log4j-api:2.24.0'
+    testImplementation 'org.apache.logging.log4j:log4j-core:2.24.0'
 }
 
 test {

--- a/src/test/java/com/vulcan/framework/hooks/Hooks.java
+++ b/src/test/java/com/vulcan/framework/hooks/Hooks.java
@@ -15,11 +15,19 @@ import com.vulcan.framework.support.ConfigManager;
 import com.vulcan.framework.support.DriverFactory;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.WebDriver;
 
 public class Hooks {
+
+    private static final Logger logger = LogManager.getLogger(Hooks.class);
+
     @Before
     public void setUp() {
+
+        logger.info("Starting scenario - setting up WebDriver and navigating to baseUrl");
+
         // Get the browser instance from DriverFactory
         WebDriver driver = DriverFactory.getDriver();
 
@@ -27,11 +35,13 @@ public class Hooks {
         String baseUrl = ConfigManager.getInstance().get("baseUrl");
 
         // Navigate to the base URL
+        logger.info("Navigating to baseUrl: {}", baseUrl);
         driver.get(baseUrl);
     }
     @After
     public void tearDown() {
         // Quit the browser after each scenario
+        logger.info("Scenario finished - quitting WebDriver");
         DriverFactory.quitDriver();
     }
 }

--- a/src/test/java/com/vulcan/framework/support/ConfigManager.java
+++ b/src/test/java/com/vulcan/framework/support/ConfigManager.java
@@ -12,12 +12,16 @@
 
 package com.vulcan.framework.support;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-
 public class ConfigManager {
+    
+    private static final Logger logger = LogManager.getLogger(ConfigManager.class);
+
     private static ConfigManager instance;
     private final Properties properties = new Properties();
 
@@ -26,17 +30,23 @@ public class ConfigManager {
     }
     public static ConfigManager getInstance() {
         if (instance == null) {
+            logger.info("Creating ConfigManager instance");
             instance = new ConfigManager();
         }
         return instance;
     }
     private void loadProperties() {
+        logger.info("Loading configuration from config.properties"); 
+
         try (InputStream input = getClass().getClassLoader().getResourceAsStream("config.properties")) {
             if (input == null) {
+                logger.error("config.properties file not found in resources directory");
                 throw new RuntimeException("config.properties file not found in resources directory.");
             }
             properties.load(input);
+            logger.info("Configuration loaded successfully");
         } catch (IOException ex) {
+            logger.error("Failed to load configuration file", ex);
             throw new RuntimeException("config.properties file not found in resources directory.");
         }
     }
@@ -44,9 +54,11 @@ public class ConfigManager {
         String value = properties.getProperty(key);
 
         if (value == null) {
+            logger.error("Property '{}' not found in config.properties", key);
             throw new RuntimeException("Property '" + key + "' not found in config.properties");
         }
 
+        logger.debug("Reading config property '{}' = '{}'", key, value);
         return value.trim();
     }
 }

--- a/src/test/java/com/vulcan/framework/support/DriverFactory.java
+++ b/src/test/java/com/vulcan/framework/support/DriverFactory.java
@@ -11,23 +11,33 @@
 
 package com.vulcan.framework.support;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver; 
 import org.openqa.selenium.firefox.FirefoxDriver;
 
 public class DriverFactory {
+
+    private static final Logger logger = LogManager.getLogger(DriverFactory.class);
+
     private static WebDriver driver;
 
     public static WebDriver getDriver() {
         if (driver == null) {
+            logger.info("WebDriver is null. Creating a new instance.");
             createDriver();
+        }else {
+            logger.debug("Reusing existing WebDriver instance.");
         }
         return driver;
     }
 
     private static void createDriver() {
         String browser = ConfigManager.getInstance().get("browser").toLowerCase();
+        logger.info("Creating WebDriver for browser: {}", browser);
+
         switch (browser) {
                 case "chrome":
                     WebDriverManager.chromedriver().setup();
@@ -38,14 +48,19 @@ public class DriverFactory {
                     driver = new FirefoxDriver();
                     break;
                 default:
+                    logger.error("Unsupported browser configured: {}", browser);
                     throw new RuntimeException("Unsupported browser: " + browser);
-        }       
+        }
+        logger.info("Maximizing browser window");       
         driver.manage().window().maximize();
     }
     public static void quitDriver() {
         if (driver != null) {
+            logger.info("Quitting WebDriver");
             driver.quit();
             driver = null;
+        }  else {
+            logger.debug("quitDriver() called but WebDriver is already null.");
         }
     }    
 }

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <!-- Console appender -->
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%d{HH:mm:ss}] [%-5level] [%c{1}] - %msg%n"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <!-- Root logger -->
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
# Add centralized logging using Log4j2

## Objective
Introduce Log4j2 as the logging framework for VulcanTestFramework to track configuration loading, WebDriver lifecycle, and scenario-level events.

## Tasks
- [ ] Add Log4j2 dependencies to build.gradle
- [ ] Create basic `log4j2.xml` with console appender
- [ ] Add logger to ConfigManager (config load, key access, errors)
- [ ] Add logger to DriverFactory (driver create, reuse, quit)
- [ ] Add logger to Hooks (scenario start/end and navigation)
- [ ] Update README with a short “Logging” section