### PR TITLE
Use gradle.properties instead of config.properties to read all framew…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,37 @@
 <!--
-
 VulcanTestFramework
 A QA Automation Project by Claudia Paola Muñoz (cpmn.tech)
-
 Copyright (c) 2025
 MIT License
-  
 -->
 
 # 🖖 VulcanTestFramework  
-**A logical, scalable, and modular UI Automation Framework built with Java, Selenium WebDriver, Cucumber (BDD), and Gradle.**
+**A logical, scalable, and modular UI + API Automation Framework built with Java 21, Selenium WebDriver, Cucumber (BDD), RestAssured, and Gradle.**
 
-> *“Logic is the cement of our civilization.” — Spock*  
+> *“Logic is the beginning of wisdom, not the end.” — Spock*  
 Inspired by Vulcan principles of clarity, precision, and efficiency.
 
 ---
 
 ## 🌌 Overview
 
-**VulcanTestFramework** is a fully modular and extensible UI automation framework designed to demonstrate industry-level engineering practices.  
-It provides a clean architecture following Page Object Model (POM), Behavior-Driven Development (BDD), and configurable execution through Gradle.
+**VulcanTestFramework** is a professional-grade automation framework designed for **UI and API testing** under a unified architecture.  
+It implements industry best practices: Page Object Model (POM), BDD, layered architecture, design patterns, externalized configuration, and centralized logging.
 
-This project serves as a **professional starter-kit**, ideal for QA automation portfolios, learning, and real-world applications.
+This project serves as a **portfolio-quality reference**, an educational template, and a foundation suitable for real-world automation teams.
 
 ---
 
 ## 🎯 Project Goals
 
-- Build a **clean, reusable, and scalable** automation framework.  
-- Demonstrate **best practices** in Selenium + Java + Cucumber architecture.  
-- Enable configuration per environment and per browser.  
-- Provide rich reporting and CI/CD integration.  
-- Document every component with clarity and logic (the Vulcan way).
+- Build a **clean, extensible, and scalable** automation framework.  
+- Provide **UI + API test automation** in one architecture.  
+- Support **environment configuration** via Gradle properties.  
+- Integrate **Log4j2** for structured logging.  
+- Promote **separation of concerns** for maintainable architecture.  
+- Prepare the framework for CI/CD, parallel execution, and reporting.
 
 ---
-
-
-## 🧩 Architecture Structure
-```bash
-VulcanTestFramework/
-├─ build.gradle
-├─ settings.gradle
-├─ README.md
-├─ /src
-│  ├─ /test
-│  │  ├─ /java
-│  │  │  └─ com.vulcan.framework
-│  │  │     ├─ hooks
-│  │  │     ├─ steps
-│  │  │     ├─ runners
-│  │  │     ├─ support
-│  │  │     │  ├─ DriverFactory.java
-│  │  │     │  ├─ ConfigManager.java
-│  │  │     │  ├─ BasePage.java
-│  │  │     │  └─ utils
-│  │  └─ /resources
-│  │     ├─ features
-│  │     └─ config.properties
-```
-### **Core Design Principles**
-- **Logical simplicity**  
-- **Single Responsibility Architecture**  
-- **Reusability and extensibility**  
-- **External configuration**  
-- **Readable test definitions (BDD)**  
-
----
-
 ## 🚀 Tech Stack
 
 | Component | Purpose |
@@ -82,21 +47,206 @@ VulcanTestFramework/
 
 ---
 
+# 🧩 Architecture Structure
+
+```bash
+VulcanTestFramework/
+├── build.gradle
+├── settings.gradle
+├── gradle.properties
+├── README.md
+└── src/
+    └── test/
+        ├── java/
+        │   └── com/vulcan/framework/
+        │       ├── config/
+        │       │   └── ConfigManager.java
+        │       ├── core/
+        │       │   └── DriverFactory.java
+        │       ├── hooks/
+        │       │   └── Hooks.java
+        │       ├── ui/
+        │       │   ├── pages/
+        │       │   │   ├── BasePage.java
+        │       │   │   └── LoginPage.java
+        │       │   ├── actions/
+        │       │   └── assertions/
+        │       ├── api/
+        │       │   ├── client/
+        │       │   ├── models/
+        │       │   ├── requests/
+        │       │   └── assertions/
+        │       ├── steps/
+        │       │   ├── ui/
+        │       │   │   └── LoginSteps.java
+        │       │   └── api/
+        │       └── runners/
+        │           └── CucumberTestRunner.java
+        └── resources/
+            └── features/
+                └── login.feature
+```
+# ⭐ Core Architectural Principles
+
+The VulcanTestFramework is designed following strict engineering and software architecture standards to ensure clarity, maintainability, and scalability.
+
+**Separation of Concerns**  
+  Every layer has a single purpose:  
+  - UI pages only contain locators + actions  
+  - UI actions layer contains high-level flows  
+  - Step definitions contain only business logic  
+  - API clients handle requests  
+  - API assertions validate responses  
+  - Hooks manage browser lifecycle  
+  - Core layer handles infrastructure
+
+**⚙️ Configuration (gradle.properties)**  
+All configuration is handled through `gradle.properties`: 
+  ```properties
+    # UI settings
+    ui.baseUrl=https://www.saucedemo.com/
+    ui.browser=chrome
+    ui.implicitWait=5  
+    # API settings
+    api.baseUrl=https://api.example.com
+    api.timeout=5000
+
+    # Environment name
+    env=dev
+  ```
+Values are injected into the JVM by Gradle and accessed using:
+  ```java
+  ConfigManager.getInstance().get("ui.baseUrl");
+  ConfigManager.getInstance().get("api.baseUrl");
+  ```
+**🔧 Logging (Log4j2)**
+The framework uses Log4j2 for structured, timestamped logging. 
+
+Gradle configuration ensures logs appear in test output:
+  ```groovy
+  testLogging {
+    events "PASSED", "FAILED", "SKIPPED"
+    showStandardStreams = true
+  }
+  ```
+All layers produce structured logs for debugging and observability. Logs include activity from:
+- ConfigManager
+- DriverFactory
+- Hooks
+- UI Pages
+- API Clients
+
+Example output:
+```
+[INFO ] ConfigManager - Reading ui.browser=chrome
+[INFO ] DriverFactory - Creating WebDriver instance (chrome)
+[INFO ] Hooks - Navigating to baseUrl: https://www.saucedemo.com/
+[DEBUG] LoginPage - Checking if login form is visible
+```
+
+**Design Patterns**  
+  - *Singleton*: ConfigManager  
+  - *Factory*: DriverFactory  
+  - *Page Object Pattern*: UI Pages  
+  - *Facade / Actions Layer*: UI flows  
+  - *API Client Pattern*: REST client abstractions  
+  - *Separation of Assertions*: UI + API assertion modules
+
+## 🧠 UI Architecture (Page Object Model)
+
+**BasePage**
+Shared UI behavior for all pages:
+- WebDriver access
+- PageFactory initialization
+- Helper methods (click, type, isDisplayed)
+- Logging included
+
+**Page Objects (ui/pages/)**
+Example: LoginPage
+- Contains locators (@FindBy)
+- Contains UI interaction logic
+- Supports domain flows like loginAs(user, password)
+
+**UI Steps (steps/ui/)**
+- Cucumber BDD steps
+- Step files act only as “scenario translators” and never contain Selenium or RestAssured logic.
+- Call into LoginPage (never WebDriver directly)
+
+## 🛰 API Architecture (Skeleton Ready)
+The framework supports API testing using RestAssured, following the same clean structure as UI.
+
+✔ api/client/BaseApiClient
+- Reads api.baseUrl and api.timeout
+- Configures RestAssured
+- Defines helper methods (get, post, etc.)
+
+✔ Domain clients (e.g., UserApiClient)
+- Implements endpoint-specific operations
+```code
+getUserById(id)
+createUser(payload)
+```
+✔ DTO models (api/models)
+- Represent JSON response bodies
+- Handled via Jackson
+
+✔ API assertions (api/assertions)
+
+Reusable checks for:
+- Status codes
+- Field equality
+- JSON structure
+
+✔ API stepdefs (steps/api)
+
+Cucumber steps that interact with API clients.
+
+
+
+
+
+- **Environment-Aware Execution**  
+ Any value (UI base URL, API endpoint, browser type, wait times) can be overridden via:  
+```bash
+  ./gradlew test -Pui.browser=firefox -Penv=qa
+```
+
+
+# 🖖 VulcanTestFramework  
+### © 2025 cpmn.tech — MIT License
+
+
+
+
+
+
+
+
 ## 🧪 Running Tests
 
-### **Run all tests**
+### **Run the full test suite**
 ```bash
 ./gradlew test
 ```
-
+### **Override browser**
+```bash
+./gradlew test -Pui.browser=firefox
+```
+### **Override UI Base URL**
+```bash
+./gradlew test -Pui.baseUrl=https://staging.example.com
+```
 ### **Run tests with tags**
 ```bash
 ./gradlew test -Dcucumber.filter.tags="@smoke"
 ```
-
-### **Override browser**
+### **Override environment**
+Future environments:
+    - config-dev.properties
+	- config-qa.properties
+	- config-prod.properties
 ```bash
-./gradlew test -Dbrowser=firefox
+./gradlew test -Penv=qa
 ```
 
 ### **Configuration**
@@ -106,40 +256,34 @@ baseUrl=https://www.tobedefined.com
 browser=chrome
 implicitWait=10
 ```
-Future environments:
-    - config-dev.properties
-	- config-qa.properties
-	- config-prod.properties
 
-Override from CLI:
-```bash
-./gradlew test -Denv=qa
-```
+
 ## 🧠 Design Decisions (The Vulcan Logic)
-    - Use Page Object Model for maintainability
-	- Use ThreadLocal WebDriver to support parallel execution
-	- Separate test logic from UI interaction
-	- Use external configuration for flexibility
-	- Use hooks to orchestrate browser lifecycle
-	- Keep code minimal, clear, and predictable
+- Use Singleton for configuration
+- Use Factory for WebDriver creation
+- Use Page Object Model for maintainability
+- Use thin step definitions for readability
+- Use hooks for browser lifecycle orchestration
+- Use external Gradle-based configuration
+- Use consistent logging across layers
+- Use clean architecture for UI + API extensibilit
 ---
 
 ## 📈 CI/CD Integration (Coming Soon)
-
-    GitHub Actions workflow will include:
-	- Java + Gradle setup
-	- Test execution
-	- Report publishing
-	- Build badge in README
+- GitHub Actions workflow will include:
+- Java + Gradle setup
+- UI + API test execution
+- Publishing test reports
+- Build badge in README
 ---
 
 ## 📝 Contributing
-    
-    Even as a personal project, standards are followed:
-    - Feature branches
-	- Meaningful commit messages
-	- PR-style development
-	- Code kept modular and documented
+Even as a personal project, professional practices are followed:
+Feature branches
+- Meaningful commit messages
+- Modular code
+- Clear documentation
+- Consistent naming conventions    
 
 # 🖖 VulcanTestFramework  
 ### © 2025 cpmn.tech — MIT License

--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,27 @@ dependencies {
 test {
     useJUnit()
 
+    // Allow Gradle to succeed even if no tests are found   
     failOnNoDiscoveredTests = false
-
-    // Allow Gradle to succeed even if no tests are found
+    
+    // Map all UI + API keys from gradle.properties into System properties
+    [
+        'ui.baseUrl',
+        'ui.browser',
+        'ui.implicitWait',
+        'api.baseUrl',
+        'api.timeout',
+        'env'
+    ].each { key ->
+        if (project.hasProperty(key)) {
+            systemProperty key, project.property(key)
+        }
+    }
+    
     // Show test results clearly in console
     testLogging {
         events "PASSED", "FAILED", "SKIPPED"
+        showStandardStreams = true
     }
 
     // Allow filtering test execution by Cucumber tags (optional)

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,18 @@
 
 org.gradle.configuration-cache=true
 
+# UI settings
+# Base URL of the application under test
+ui.baseUrl=https://www.saucedemo.com/
+# Browser to use (we'll wire this later in DriverFactory)
+ui.browser=chrome
+# Implicit wait in seconds (if you decide to use it)
+ui.implicitWait=5
+
+# API settings (for future API layer)
+api.baseUrl=https://api.example.com
+api.timeout=5000
+
+# Example: environment name
+env=dev
+

--- a/src/test/java/com/vulcan/framework/config/ConfigManager.java
+++ b/src/test/java/com/vulcan/framework/config/ConfigManager.java
@@ -12,22 +12,21 @@
 
 package com.vulcan.framework.config;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
 
 public class ConfigManager {
     
     private static final Logger logger = LogManager.getLogger(ConfigManager.class);
 
-    private static ConfigManager instance;
-    private final Properties properties = new Properties();
+    private static ConfigManager instance;    
 
     private ConfigManager() {
-        loadProperties();
+        logger.info("ConfigManager initialized. Reading configuration from system properties (gradle.properties).");
     }
     public static ConfigManager getInstance() {
         if (instance == null) {
@@ -36,27 +35,16 @@ public class ConfigManager {
         }
         return instance;
     }
-    private void loadProperties() {
-        logger.info("Loading configuration from config.properties"); 
-
-        try (InputStream input = getClass().getClassLoader().getResourceAsStream("config.properties")) {
-            if (input == null) {
-                logger.error("config.properties file not found in resources directory");
-                throw new RuntimeException("config.properties file not found in resources directory.");
-            }
-            properties.load(input);
-            logger.info("Configuration loaded successfully");
-        } catch (IOException ex) {
-            logger.error("Failed to load configuration file", ex);
-            throw new RuntimeException("config.properties file not found in resources directory.");
-        }
-    }
     public String get(String key) {
-        String value = properties.getProperty(key);
+        String value = System.getProperty(key);
 
         if (value == null) {
-            logger.error("Property '{}' not found in config.properties", key);
-            throw new RuntimeException("Property '" + key + "' not found in config.properties");
+            logger.error(
+                "Configuration property '{}' not found in system properties. " +
+                "Make sure it is defined in gradle.properties or passed via -P/-D.",
+                key
+            );
+            throw new RuntimeException("Property '" + key + "' not found in system properties");
         }
 
         logger.debug("Reading config property '{}' = '{}'", key, value);

--- a/src/test/java/com/vulcan/framework/core/DriverFactory.java
+++ b/src/test/java/com/vulcan/framework/core/DriverFactory.java
@@ -17,14 +17,15 @@ import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver; 
 import org.openqa.selenium.firefox.FirefoxDriver;
-
+import org.openqa.selenium.support.ui.WebDriverWait;
 import com.vulcan.framework.config.ConfigManager;
+import java.time.Duration;
 
 public class DriverFactory {
 
     private static final Logger logger = LogManager.getLogger(DriverFactory.class);
-
     private static WebDriver driver;
+    private static WebDriverWait wait;
 
     public static WebDriver getDriver() {
         if (driver == null) {
@@ -37,7 +38,9 @@ public class DriverFactory {
     }
 
     private static void createDriver() {
-        String browser = ConfigManager.getInstance().get("browser").toLowerCase();
+        String browser = ConfigManager.getInstance().get("ui.browser").toLowerCase();
+        int implicitWait = Integer.parseInt(ConfigManager.getInstance().get("ui.implicitWait"));
+
         logger.info("Creating WebDriver for browser: {}", browser);
 
         switch (browser) {
@@ -53,6 +56,10 @@ public class DriverFactory {
                     logger.error("Unsupported browser configured: {}", browser);
                     throw new RuntimeException("Unsupported browser: " + browser);
         }
+
+        logger.info("Setting implicit wait to {} seconds", implicitWait);
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(implicitWait));
+
         logger.info("Maximizing browser window");       
         driver.manage().window().maximize();
     }

--- a/src/test/java/com/vulcan/framework/hooks/Hooks.java
+++ b/src/test/java/com/vulcan/framework/hooks/Hooks.java
@@ -33,7 +33,7 @@ public class Hooks {
         WebDriver driver = DriverFactory.getDriver();
 
         // Read the base URL from config.properties
-        String baseUrl = ConfigManager.getInstance().get("baseUrl");
+        String baseUrl = ConfigManager.getInstance().get("ui.baseUrl");
 
         // Navigate to the base URL
         logger.info("Navigating to baseUrl: {}", baseUrl);


### PR DESCRIPTION
	1.	Updating ConfigManager to use System.getProperty(...)
	2.	Making sure build.gradle passes ui.* and api.* properties from gradle.properties into the JVM
	3.	Verifying gradle.properties is in the correct place
	4.	Re-running tests with clean so old classes are not reused