### PR TITLE
Create a reusable UI utility layer to standardize explicit waits and …

### DIFF
--- a/src/test/java/com/vulcan/framework/core/WaitUtils.java
+++ b/src/test/java/com/vulcan/framework/core/WaitUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 cpmn.tech
+ *
+ * Licensed under the MIT License.
+ * You may obtain a copy of the License at
+ * https://opensource.org/licenses/MIT
+ *
+ * This file is part of the VulcanTestFramework project.
+ * A QA Automation Project by Claudia Paola Muñoz (cpmn.tech)
+ */
+
+package com.vulcan.framework.core;
+
+import java.time.Duration;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+/**
+ * WaitUtils centralize explicit waits used by the UI layer.
+ * 
+ * Why:
+ * - Stabilizes UI automation by waiting for conditions before interacting
+ * - Keeps wait logic consistent and reusable across the framework
+ * 
+ * Notes:
+ * - ONLY use explicit waits here; avoid implicit waits in WebDriver setup
+ * - Timeout is passed from BasePage to allow scenario-specific configuration
+ */
+public class WaitUtils {
+    private final WebDriver driver;
+    private final Duration timeout;
+
+    public WaitUtils(WebDriver driver, int timeoutSeconds) {
+        if(driver == null) {
+            throw new IllegalArgumentException("WebDriver cannot be null");
+        }
+        if (timeoutSeconds <= 0) {
+            throw new IllegalArgumentException("Timeout must be greater than zero");
+        }
+        this.driver = driver;
+        this.timeout = Duration.ofSeconds(timeoutSeconds);        
+    }
+
+    /** Wait until element is visible. Returns the same element once visible */    
+    public WebElement waitForVisible(WebElement element) {
+        return new WebDriverWait(driver, timeout)
+            .until(ExpectedConditions.visibilityOf(element));
+    }
+
+    /** Wait until element is clickable. Returns the same element once clickable */
+    public WebElement waitForClickable(WebElement element) {
+        return new WebDriverWait(driver, timeout)
+            .until(ExpectedConditions.elementToBeClickable(element));
+    }
+    /** Wait until title contains expected text */
+    public boolean waitForTitleContains(String expectedText) {
+        return new WebDriverWait(driver, timeout)
+            .until(ExpectedConditions.titleContains(expectedText));
+    }
+
+    /** Wait until URL contains expected text */
+    public boolean waitForUrlContains(String expectedText) {
+        return new WebDriverWait(driver, timeout)
+            .until(ExpectedConditions.urlContains(expectedText));
+    }
+}

--- a/src/test/java/com/vulcan/framework/ui/actions/ElementActions.java
+++ b/src/test/java/com/vulcan/framework/ui/actions/ElementActions.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025 cpmn.tech
+ *
+ * Licensed under the MIT License.
+ * You may obtain a copy of the License at
+ * https://opensource.org/licenses/MIT
+ *
+ * This file is part of the VulcanTestFramework project.
+ * A QA Automation Project by Claudia Paola Muñoz (cpmn.tech)
+ */
+
+package com.vulcan.framework.ui.actions;
+
+import com.vulcan.framework.core.WaitUtils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.openqa.selenium.WebElement;
+
+/**
+ * ElementActions provides a single, consistent API for UI interactions.
+ *
+ * Why:
+ * - Keeps Page Objects clean (they describe the page, not the timing logic).
+ * - Adds stability (explicit waits before actions).
+ * - Adds observability (standard logs for every action).
+ *
+ * Design rule:
+ * - All click/type/read checks should go through this class.
+ */
+public class ElementActions {
+
+    private static final Logger logger = LogManager.getLogger(ElementActions.class);
+
+    private final WaitUtils wait;
+
+    public ElementActions(WaitUtils wait) {
+        if (wait == null) {
+            throw new IllegalArgumentException("wait cannot be null");
+        }
+        this.wait = wait;
+    }
+
+    /** Click with a friendly element name for logs. */
+    public void click(WebElement element, String name) {
+        String safeName = normalizeName(name);
+        logger.info("UI ACTION | click | element='{}'", safeName);
+        wait.waitForClickable(element).click();
+    }
+
+    /** Type text into an element (with masking if it's sensitive). */
+    public void type(WebElement element, String name, String value) {
+        String safeName = normalizeName(name);
+        boolean sensitive = isSensitiveField(safeName);
+
+        logger.info("UI ACTION | type | element='{}' | value={}",
+                safeName,
+                sensitive ? "<masked>" : String.valueOf(value));
+
+        WebElement visible = wait.waitForVisible(element);
+        visible.clear();
+        visible.sendKeys(value);
+    }
+
+    /** Explicit “sensitive” typing: always masked, even if name doesn't contain password. */
+    public void typeSensitive(WebElement element, String name, String value) {
+        String safeName = normalizeName(name);
+        logger.info("UI ACTION | typeSensitive | element='{}' | value=<masked>", safeName);
+
+        WebElement visible = wait.waitForVisible(element);
+        visible.clear();
+        visible.sendKeys(value);
+    }
+
+    /** Returns text after waiting for visibility. */
+    public String getText(WebElement element, String name) {
+        String safeName = normalizeName(name);
+        WebElement visible = wait.waitForVisible(element);
+        String text = visible.getText();
+        logger.info("UI ACTION | getText | element='{}' | text='{}'", safeName, text);
+        return text;
+    }
+
+    /** Safe visibility check (doesn't throw if element isn't visible). */
+    public boolean isDisplayed(WebElement element, String name) {
+        String safeName = normalizeName(name);
+        try {
+            boolean displayed = element.isDisplayed();
+            logger.info("UI ACTION | isDisplayed | element='{}' | displayed={}", safeName, displayed);
+            return displayed;
+        } catch (Exception e) {
+            logger.info("UI ACTION | isDisplayed | element='{}' | displayed=false (exception={})",
+                    safeName, e.getClass().getSimpleName());
+            return false;
+        }
+    }
+
+    private String normalizeName(String name) {
+        if (name == null || name.trim().isEmpty()) return "unknown-element";
+        return name.trim();
+    }
+
+    private boolean isSensitiveField(String elementName) {
+        String n = elementName.toLowerCase();
+        return n.contains("password") || n.contains("secret") || n.contains("token");
+    }
+}

--- a/src/test/java/com/vulcan/framework/ui/pages/LoginPage.java
+++ b/src/test/java/com/vulcan/framework/ui/pages/LoginPage.java
@@ -14,7 +14,15 @@ package com.vulcan.framework.ui.pages;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
+/**
+ * LoginPage represents the SauceDemo login screen.
+ *
+ * Rules:
+ * - Page methods are low-level actions on the page (enter/click/check).
+ * - High-level flows belong in LoginActions (e.g., login as role/user).
+ */
 public class LoginPage extends BasePage {
+
     @FindBy(id = "user-name")
     private WebElement usernameField;
 
@@ -30,30 +38,31 @@ public class LoginPage extends BasePage {
     }
 
     public void enterUsername(String username) {
-        logger.info("Entering username: {}", username);
-        type(usernameField, username);
+        type(usernameField, "usernameField", username);
     }
 
     public void enterPassword(String password) {
-        logger.info("Entering password");
-        type(passwordField, password);
+        // Never log raw passwords
+        typeSensitive(passwordField, "passwordField", password);
     }
 
     public void clickLogin() {
-        logger.info("Clicking login button");
-        click(loginButton);
+        click(loginButton, "loginButton");
     }
 
     public boolean isLoginFormVisible() {
-        logger.info("Checking if login form is visible");
-        return isDisplayed(usernameField) && isDisplayed(passwordField) && isDisplayed(loginButton);
+        return isDisplayed(usernameField, "usernameField")
+                && isDisplayed(passwordField, "passwordField")
+                && isDisplayed(loginButton, "loginButton");
     }
 
+    /**
+     * Low-level convenience method.
+     * (The recommended place for high-level flows is LoginActions.)
+     */
     public void loginAs(String username, String password) {
-        logger.info("Performing login as user: {}", username);
         enterUsername(username);
         enterPassword(password);
         clickLogin();
     }
-    
 }

--- a/src/test/resources/features/ui/login.feature
+++ b/src/test/resources/features/ui/login.feature
@@ -21,13 +21,13 @@ Feature: Login
       And I should see the login form
       Then I log in as role "ADMINISTRATOR"
    
-   @smoke @Login
+   @smoke
    Scenario: Open login page as a Performance user
       Given I am on the login page
       And I should see the login form
       Then I log in as role "PERFORMANCE"
 
-   @smoke @Login
+   @smoke
    Scenario: Open login page as Standard user
       Given I am on the login page
       And I should see the login form


### PR DESCRIPTION
- [x] Create core/WaitUtils (explicit waits only)
    - [x] waitForVisible(By/WebElement)
    - [x] waitForClickable(By/WebElement)
    - [x] waitForUrlContains / waitForTitleContains (optional)
- [x] Create ui/actions/ElementActions
    - [x] click(WebElement, String name)
    - [x] type(WebElement, String name, String value) (mask sensitive fields)
    - [x] getText(WebElement, String name)
    - [x] isDisplayed(WebElement, String name)
- [x] Refactor ui/pages/BasePage
    - [x] remove direct interactions
    - [x] delegate to ElementActions/WaitUtils
    - [x] keep PageFactory init
- [x] Update LoginPage to pass element names to actions
- [x] Run ./gradlew uiTest and confirm same scenario passes with cleaner logs